### PR TITLE
Improvements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "singleQuote": true
+  }
+  

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) Klickpages <accounts@klickpages.com.br>
 Copyright (c) 2021 Atlas Lift Tech, Inc.
+Copyright (c) Dotfile <contact@dotfile.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,25 +1,31 @@
-# Insomnia Core Repo Sync Plugin
+# Insomnia Core Repo Sync Plugin 3
 
 This plugin was developed to make it easier to sync workspaces in a given repository.
 
 To use it, just install in your Insomnia Core application and go to > `Repo Sync - Configure` and set at the folder where you want your workspace config files to be exported/imported from.
 
-Then you can go to `Repo Sync - Export Workspace` to instantly export your current workspace to your repo and can use `Repo Sync - Import Workspace` to import any repository changes on the current workspace. Each workspace will generate a `<workspace-name>.yml` file inside your repository.
+Then you can go to `Repo Sync - Export Workspace` to instantly export your current workspace to your repo and can use `Repo Sync - Import Workspace` to import any repository changes on the current workspace. Each workspace will generate a `<workspace-name>.json` file inside your repository.
 
 We suggest you to use it with a git repository where you can create versions of your workspaces configs.
 
+## Changelog
+
+See [Releases](https://github.com/DotfileTech/insomnia-plugin-repo-sync-3/releases)
+
 ## History
 
-This plugin was forked from [insomnia-plugin-repo-sync](https://github.com/klickpages/insomnia-plugin-repo-sync) due to lack of active maintenance.
+This plugin was forked from [insomnia-plugin-repo-sync-v2](https://github.com/Atlas-LiftTech/insomnia-plugin-repo-sync-2) due to lack of active maintenance, which was itself forked from [insomnia-plugin-repo-sync](https://github.com/klickpages/insomnia-plugin-repo-sync) due to lack of active maintenance.
+
+At Dotfile, we synchronize our Insomnia workspace in our mono-repo, code and Insomnia requests changes are reviewed together. To make the review easier, we needed to clean the export by moving to json format and removing noisy changes like the `modified` attribute getting updated even when the request hasn't been updated.
 
 ## Contributions
 
-Contributions are welcome.  Please open an issue to discuss your idea prior to sending a PR.
+Contributions are welcome. Please open an issue to discuss your idea prior to sending a PR.
 
 ## MIT License
 
-See https://github.com/Atlas-LiftTech/insomnia-plugin-repo-sync-2/blob/master/LICENSE.
+See <https://github.com/DotfileTech/insomnia-plugin-repo-sync-3/blob/master/LICENSE>.
 
-## About Atlas LiftTech
+## About Dotfile
 
-This library is sponsored by [Atlas Lift Tech](https://atlaslifttech.com/).  Atlas Lift Tech is a [safe patient handling and mobility (SPHM)](https://atlaslifttech.com/program-management/) solution provider, helping hospitals improve patient outcomes and improve patient mobility.
+This library is sponsored by [Dotfile](https://www.dotfile.com/). Dotfile is the onboarding orchestration platform that helps you onboard clients and suppliers 10x faster while staying compliant.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,14 @@
 {
-  "name": "@klicksite/insomnia-plugin-repo-sync",
-  "version": "0.1.0",
-  "lockfileVersion": 1
+  "name": "insomnia-plugin-repo-sync-3",
+  "version": "3.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "insomnia-plugin-repo-sync-3",
+      "version": "3.0.0",
+      "license": "MIT",
+      "devDependencies": {}
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "insomnia-plugin-repo-sync-2",
-  "version": "2.0.1",
-  "author": "Anton Vishnyak <avishnyak@atlaslifttech.com>",
+  "name": "insomnia-plugin-repo-sync-3",
+  "version": "3.0.0",
+  "author": "Dotfile <contact@dotfile.com>",
   "description": "Sync your workspace to a Git repository.",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Atlas-LiftTech/insomnia-plugin-repo-sync-2.git"
+    "url": "git+https://github.com/DotfileTech/insomnia-plugin-repo-sync-3.git"
   },
   "keywords": [
     "insomnia",
@@ -14,12 +14,12 @@
     "git"
   ],
   "bugs": {
-    "url": "https://github.com/Atlas-LiftTech/insomnia-plugin-repo-sync-2/issues"
+    "url": "https://github.com/DotfileTech/insomnia-plugin-repo-sync-3/issues"
   },
   "main": "src/index.js",
   "insomnia": {
-    "name": "repo-sync",
-    "displayName": "Repo Sync Plugin v2",
+    "name": "repo-sync-3",
+    "displayName": "Repo Sync Plugin v3",
     "description": "This plugin allows users to sync workspaces in a configured repository.",
     "images": {
       "icon": "icon.svg"
@@ -29,6 +29,6 @@
     }
   },
   "dependencies": {},
-  "homepage": "https://github.com/Atlas-LiftTech/insomnia-plugin-repo-sync-2#readme",
+  "homepage": "https://github.com/DotfileTech/insomnia-plugin-repo-sync-3#readme",
   "devDependencies": {}
 }

--- a/src/ScreenHelper.js
+++ b/src/ScreenHelper.js
@@ -7,13 +7,15 @@ class ScreenHelper {
   static async askRepoPath(context, options = {}) {
     await context.app.alert(
       'Select repository',
-      `Choose the repository to synchronize your workspace\nCurrent path: ${options.currentPath}`
+      `Choose the repository to synchronize your workspace\nCurrent path: ${
+        options.currentPath ?? 'none'
+      }`
     );
     const path = await context.app.showSaveDialog({
       defaultPath: options.workspaceName,
     });
 
-    return dirname(path);
+    return path ? dirname(path) : null;
   }
 }
 

--- a/src/ScreenHelper.js
+++ b/src/ScreenHelper.js
@@ -1,15 +1,17 @@
 const { dirname } = require('path');
 class ScreenHelper {
   static async alertError(context, message) {
-    return await context.app.alert('Erro!', message);
+    return await context.app.alert('Error!', message);
   }
 
-  static async askRepoPath(context, options={}) {
+  static async askRepoPath(context, options = {}) {
     await context.app.alert(
       'Select repository',
-      `Chose the repository to synchronize your workspace\nCurrent path: ${options.currentPath}`
+      `Choose the repository to synchronize your workspace\nCurrent path: ${options.currentPath}`
     );
-    const path = await context.app.showSaveDialog({defaultPath: options.workspaceName});
+    const path = await context.app.showSaveDialog({
+      defaultPath: options.workspaceName,
+    });
 
     return dirname(path);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ module.exports.workspaceActions = [
       });
 
       const exported = JSON.parse(rawJsonString);
-
+      
       exported.resources.forEach((resource) => {
         // Insomnia update the `modified` of a resource even when the resource
         // has only been open in the app. This is very noisy when reviewing
@@ -33,6 +33,14 @@ module.exports.workspaceActions = [
         // the exports
         if (resource.modified && resource.created) {
           resource.modified = resource.created;
+        }
+
+        // Secure cookie should not be sync because they could leak
+        // authentication credentials
+        if (resource._type === 'cookie_jar') {
+          resource.cookies = resource.cookies.filter(
+            (cookie) => !cookie.secure
+          );
         }
       });
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,16 @@ module.exports.workspaceActions = [
 
       const exported = JSON.parse(rawJsonString);
 
+      exported.resources.forEach((resource) => {
+        // Insomnia update the `modified` of a resource even when the resource
+        // has only been open in the app. This is very noisy when reviewing
+        // changes in requests so `modified` is overwrite with `created` in
+        // the exports
+        if (resource.modified && resource.created) {
+          resource.modified = resource.created;
+        }
+      });
+
       fs.writeFileSync(
         `${path}/${models.workspace.name}.json`,
         JSON.stringify(exported, null, 2)

--- a/src/index.js
+++ b/src/index.js
@@ -9,48 +9,53 @@ const verifyRepoConfig = async (repo, context) => {
   return false;
 };
 
-module.exports.workspaceActions = [{
-  label: 'Repo Sync - Export Workspace',
-  icon: 'fa-download',
-  action: async (context, models) => {
-    const repo = new WorkspaceRepo(context);
-    if (!await verifyRepoConfig(repo, context)) return;
+module.exports.workspaceActions = [
+  {
+    label: 'Repo Sync - Export Workspace',
+    icon: 'fa-download',
+    action: async (context, models) => {
+      const repo = new WorkspaceRepo(context);
+      if (!(await verifyRepoConfig(repo, context))) return;
 
-    const path = await repo.getPath();
-    const ex = await context.data.export.insomnia({
-      includePrivate: false,
-      format: 'yaml',
-      workspace: models.workspace,
-    });
+      const path = await repo.getPath();
+      const ex = await context.data.export.insomnia({
+        includePrivate: false,
+        format: 'yaml',
+        workspace: models.workspace,
+      });
 
-    fs.writeFileSync(`${path}/${models.workspace.name}.yml`, ex);
+      fs.writeFileSync(`${path}/${models.workspace.name}.yml`, ex);
+    },
   },
-},
-{
-  label: 'Repo Sync - Import Workspace',
-  icon: 'fa-upload',
-  action: async (context, models) => {
-    const repo = new WorkspaceRepo(context);
-    if (!await verifyRepoConfig(repo, context)) return;
+  {
+    label: 'Repo Sync - Import Workspace',
+    icon: 'fa-upload',
+    action: async (context, models) => {
+      const repo = new WorkspaceRepo(context);
+      if (!(await verifyRepoConfig(repo, context))) return;
 
-    const path = await repo.getPath();
-    const imported = fs.readFileSync(`${path}/${models.workspace.name}.yml`, 'utf8');
+      const path = await repo.getPath();
+      const imported = fs.readFileSync(
+        `${path}/${models.workspace.name}.yml`,
+        'utf8'
+      );
 
-    await context.data.import.raw(imported);
+      await context.data.import.raw(imported);
+    },
   },
-},
-{
-  label: 'Repo Sync - Configure',
-  icon: 'fa-cog',
-  action: async (context, models) => {
-    const repo = new WorkspaceRepo(context);
+  {
+    label: 'Repo Sync - Configure',
+    icon: 'fa-cog',
+    action: async (context, models) => {
+      const repo = new WorkspaceRepo(context);
 
-    const repoPath = await ScreenHelper.askRepoPath(context, {
-      currentPath: await repo.getPath(),
-      workspaceName: models.workspace.name,
-    });
-    if (repoPath == null) return;
+      const repoPath = await ScreenHelper.askRepoPath(context, {
+        currentPath: await repo.getPath(),
+        workspaceName: models.workspace.name,
+      });
+      if (repoPath == null) return;
 
-    await repo.setPath(repoPath);
+      await repo.setPath(repoPath);
+    },
   },
-}];
+];

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,18 @@ module.exports.workspaceActions = [
       if (!(await verifyRepoConfig(repo, context))) return;
 
       const path = await repo.getPath();
-      const ex = await context.data.export.insomnia({
+      const rawJsonString = await context.data.export.insomnia({
         includePrivate: false,
-        format: 'yaml',
+        format: 'json',
         workspace: models.workspace,
       });
 
-      fs.writeFileSync(`${path}/${models.workspace.name}.yml`, ex);
+      const exported = JSON.parse(rawJsonString);
+
+      fs.writeFileSync(
+        `${path}/${models.workspace.name}.json`,
+        JSON.stringify(exported, null, 2)
+      );
     },
   },
   {
@@ -36,7 +41,7 @@ module.exports.workspaceActions = [
 
       const path = await repo.getPath();
       const imported = fs.readFileSync(
-        `${path}/${models.workspace.name}.yml`,
+        `${path}/${models.workspace.name}.json`,
         'utf8'
       );
 


### PR DESCRIPTION
## What's new

- ✨ ignore `modified` on resource by overwriting it with `created`
- ✨ change export format to json
- 🐛 error when cancelling export selection
- 🎨 add prettier configuration and fix style
- 📝 update README to DotfileTech organisation

## Testing

1.
    - clone this repository inside your insomnia plugin folder, disable `insomnia-plugin-repo-sync-2` plugin
    - do _Repo Sync - Configure_ and _Repo Sync - Export Workspace_ this will create the export in json
    - navigate in the collection, trigger a request that store a secure cookie
    - do _Repo Sync - Export Workspace_ => the only change should be the `__export_date`

2.
    - do _Repo Sync - Configure_ but close the system folder picker => no error anymore
---

See also [E-313](https://linear.app/dotfile/issue/E-313) (Dotfile only link)