### PR TITLE
repository path per workspace

### DIFF
--- a/src/WorkspaceRepo.js
+++ b/src/WorkspaceRepo.js
@@ -1,20 +1,19 @@
-const storeKey = 'insomnia-plugin-repo-sync-workspace';
-
 class WorkspaceRepo {
-  constructor(context) {
+  constructor(context, workspace) {
     this.context = context;
+    this.storeKey = 'insomnia-plugin-repo-sync-workspace-' + workspace._id;
   }
 
   async getPath() {
-    return await this.context.store.getItem(storeKey);
+    return await this.context.store.getItem(this.storeKey);
   }
 
   async setPath(path) {
-    return await this.context.store.setItem(storeKey, path);
+    return await this.context.store.setItem(this.storeKey, path);
   }
 
   async isConfigured() {
-    return await this.context.store.hasItem(storeKey);
+    return await this.context.store.hasItem(this.storeKey);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports.workspaceActions = [
     label: 'Repo Sync - Export Workspace',
     icon: 'fa-download',
     action: async (context, models) => {
-      const repo = new WorkspaceRepo(context);
+      const repo = new WorkspaceRepo(context, models.workspace);
       if (!(await verifyRepoConfig(repo, context))) return;
 
       const path = await repo.getPath();
@@ -54,7 +54,7 @@ module.exports.workspaceActions = [
     label: 'Repo Sync - Import Workspace',
     icon: 'fa-upload',
     action: async (context, models) => {
-      const repo = new WorkspaceRepo(context);
+      const repo = new WorkspaceRepo(context, models.workspace);
       if (!(await verifyRepoConfig(repo, context))) return;
 
       const path = await repo.getPath();
@@ -70,7 +70,7 @@ module.exports.workspaceActions = [
     label: 'Repo Sync - Configure',
     icon: 'fa-cog',
     action: async (context, models) => {
-      const repo = new WorkspaceRepo(context);
+      const repo = new WorkspaceRepo(context, models.workspace);
 
       const repoPath = await ScreenHelper.askRepoPath(context, {
         currentPath: await repo.getPath(),


### PR DESCRIPTION
StoreKey is currently a constant. This is based on assumption that if we have many workspaces, all their exports are located in one folder. It causes problems if we have multiple workspaces whose exports are stored in different repositories (or multiple projects with workspaces stored in different repositories). I propose updating the pertinent logic so that each workspace's repo path is stored separately. Another approach would be to have a path per project, not per workspace.

Applying this update means that Repo Sync configuration has to be performed again for all workspaces.